### PR TITLE
Update TabEdit to work with latest fugitive.vim

### DIFF
--- a/plugin/conflicted.vim
+++ b/plugin/conflicted.vim
@@ -50,10 +50,10 @@ function! ConflictedTabLabel(tabnr)
 endfunction
 
 function! s:TabEdit(parent)
-  Gtabedit :1
+  Gtabedit :1:%
   let b:conflicted_version = 'base'
   diffthis
-  execute 'Gvsplit :' . s:VersionNumber(a:parent)
+  execute 'Gvsplit :' . s:VersionNumber(a:parent) . '.%'
   let b:conflicted_version = a:parent
   diffthis
   wincmd r


### PR DESCRIPTION
Fugitive.vim [updated the `s:Expand` function a few days ago](https://github.com/tpope/vim-fugitive/blame/0f20c35b626b0b5e80428099a3a4cd9469683f86/autoload/fugitive.vim#L861), and I
ran into some errors this morning when using vim-conflicted:

```
Error detected while processing function
/Users/anhari/.vim/bundle/vim-conflicted/plugin/conflicted.vim|14| <SNR>138_Conflicted[4]
/Users/anhari/.vim/bundle/vim-conflicted/plugin/conflicted.vim|21| <SNR>138_Merger[4]
/Users/anhari/.vim/bundle/vim-conflicted/plugin/conflicted.vim|53| <SNR>138_TabEdit[1]
fugitive: Use ':1:%' instead of ':1'
line    4:
fugitive: Use ':2:%' instead of ':2'
```



I think this should fix things, but might need a closer look since my
vimscript is a bit rough :)