### PR TITLE
Use Gdiffsplit! with fugitive 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ file. These versions are:
 For each conflicted file, Conflicted will open 3 tabs, each with a different
 diff view presented:
 
-1. **Gdiff 3-way** - 3 way diff comparing the upstream, working, and local
+1. **Gdiffsplit! 3-way** - 3 way diff comparing the upstream, working, and local
    versions of the file.
 
 ![Tab 1 - Working](./images/tab1.png)

--- a/plugin/conflicted.vim
+++ b/plugin/conflicted.vim
@@ -15,7 +15,13 @@ function! s:Conflicted()
 endfunction
 
 function! s:Merger()
-  Gdiff
+  " Shim to support Fugitive 3.0 and prior versions
+  if exists(":Gdiffsplit!")
+    Gdiffsplit!
+  else
+    Gdiff
+  endif
+
   call s:MapTargetedDiffgets()
   call s:SetVersionStatuslines()
   call s:TabEdit('upstream')


### PR DESCRIPTION
Fugitive made a change in how diff splits are rendered in v3.0, where
the default is now a two-pane view. To retain the three-pane view for
our plugin, we need to use the new `:Gdiffsplit!` command instead.

This change leaves a shim where if the 3.0 command isn't defined, we'll
retain the old behavior.

After creating this, I realized it's an alternate implementation of #17.