### PR TITLE
support 3-way vertical diff by default

### DIFF
--- a/plugin/conflicted.vim
+++ b/plugin/conflicted.vim
@@ -16,8 +16,8 @@ endfunction
 
 function! s:Merger()
   " Shim to support Fugitive 3.0 and prior versions
-  if exists(":Gdiffsplit!")
-    Gdiffsplit!
+  if exists(':Gvdiffsplit')
+    Gvdiffsplit!
   else
     Gdiff
   endif


### PR DESCRIPTION
as a followup to https://github.com/christoomey/vim-conflicted/issues/18, which resulted in https://github.com/christoomey/vim-conflicted/pull/19 being merged, but which did not solve the problem for me, I submit this PR, which does.

The original issue is that the default split is only 2-way after a vim-fugitive update.

The PR to resolve it doesn't work for me.  If I remove the `!` from the changes it introduced, I get the three-way split back, but horizontal instead of vertical.  

This PR removes the `!` and uses the vertical split.