### PR TITLE
Fix for filenames with spaces

### DIFF
--- a/plugin/conflicted.vim
+++ b/plugin/conflicted.vim
@@ -8,7 +8,7 @@ let s:diffget_local_map = 'dgl'
 let s:diffget_upstream_map = 'dgu'
 
 function! s:Conflicted()
-  args `git ls-files -u \| awk '{print $4}' \| sort -u`
+  args `git diff --name-only --diff-filter=U`
   set tabline=%!ConflictedTabline()
   set guitablabel=%{ConflictedGuiTabLabel()}
   Merger


### PR DESCRIPTION
How to replicate the problem:

```
git co -b foo
echo hello > "a b"
git add "a b"
git commit -m x
git co master
git co -b bar
echo world > "a b"
git add "a b"
git commit -m y
git rebase foo
git conflicted
```

Prior to this, conflicted would try to load for a file "a" because awk thinks the space in the name is a column separator.