### PR TITLE
Silently set guitablabel, so no errors are thrown in neovim

### DIFF
--- a/plugin/conflicted.vim
+++ b/plugin/conflicted.vim
@@ -10,7 +10,7 @@ let s:diffget_upstream_map = 'dgu'
 function! s:Conflicted()
   args `git diff --name-only --diff-filter=U`
   set tabline=%!ConflictedTabline()
-  set guitablabel=%{ConflictedGuiTabLabel()}
+  silent! set guitablabel=%{ConflictedGuiTabLabel()}
   Merger
 endfunction
 


### PR DESCRIPTION
`vim-conflicted` throw errors on `neovim` because `guitablabel` is not implemented.

Silencing the setting is the simplest way to avoid the errors without breaking compatibility.